### PR TITLE
fix:优化主界面细节

### DIFF
--- a/components/accounts/account-switcher.tsx
+++ b/components/accounts/account-switcher.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { useAccountContext } from "@/components/accounts/account-provider";
 import { LoginDialog } from "@/components/accounts/login-dialog";
 import { SkinCapeManager } from "@/components/accounts/skin-cape-manager";
 import { X, Check, Plus, Trash2, Shirt } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarColor, getAvatarInitials } from "@/lib/utils";
 import { overlayFade, scaleIn } from "@/lib/motion";
 import type { Account } from "@/types";
 
@@ -93,11 +93,13 @@ export function AccountSwitcher({
                         }}
                       >
                         <Avatar>
-                          {profile.skinUrl && (
-                            <AvatarImage src={profile.skinUrl} alt={profile.name} />
-                          )}
-                          <AvatarFallback>
-                            {profile.name.charAt(0).toUpperCase()}
+                          <AvatarFallback
+                            className={cn(
+                              getAvatarColor(profile.name),
+                              "text-white font-medium"
+                            )}
+                          >
+                            {getAvatarInitials(profile.name)}
                           </AvatarFallback>
                         </Avatar>
                         <div className="flex-1 min-w-0">

--- a/components/launch/floating-launch-button.tsx
+++ b/components/launch/floating-launch-button.tsx
@@ -42,11 +42,12 @@ export function FloatingLaunchButton() {
     "未选择版本"
   );
 
-  // 初始化位置
+  // 初始化位置：横轴 1/2、纵轴 1/3（按钮初始为收起态 60×60，居中放置）
   useEffect(() => {
+    const BTN_SIZE = 60;
     setPosition({
-      x: 20,
-      y: window.innerHeight - 80,
+      x: window.innerWidth / 2 - BTN_SIZE / 2,
+      y: window.innerHeight / 3 - BTN_SIZE / 2,
     });
   }, []);
 

--- a/components/launch/floating-launch-button.tsx
+++ b/components/launch/floating-launch-button.tsx
@@ -181,7 +181,7 @@ export function FloatingLaunchButton() {
         stiffness: 300,
         damping: 30
       }}
-      className="fixed z-50 cursor-move"
+      className="fixed z-50 cursor-move select-none"
       style={{
         left: position.x,
         top: position.y,

--- a/components/launch/launch-panel.tsx
+++ b/components/launch/launch-panel.tsx
@@ -3,13 +3,14 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { AnimatePresence, motion } from "framer-motion";
 import { invoke } from "@tauri-apps/api/core";
 import { useLaunchContext } from "@/components/launch/launch-provider";
 import { useAccountContext } from "@/components/accounts/account-provider";
 import { LaunchStatusBadge } from "@/components/launch/launch-status-badge";
 import { fadeSlideUp } from "@/lib/motion";
+import { cn, getAvatarColor, getAvatarInitials } from "@/lib/utils";
 import {
   Play,
   Loader2,
@@ -101,11 +102,13 @@ export function LaunchPanel() {
           {selectedProfile && (
             <div className="flex items-center gap-2">
               <Avatar size="sm">
-                {selectedProfile.skinUrl && (
-                  <AvatarImage src={selectedProfile.skinUrl} alt={selectedProfile.name} />
-                )}
-                <AvatarFallback>
-                  {selectedProfile.name.charAt(0).toUpperCase()}
+                <AvatarFallback
+                  className={cn(
+                    getAvatarColor(selectedProfile.name),
+                    "text-white font-medium"
+                  )}
+                >
+                  {getAvatarInitials(selectedProfile.name)}
                 </AvatarFallback>
               </Avatar>
               <div className="text-right">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,6 +7,49 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * 玩家头像纯色背景调色板
+ * 用于根据玩家名生成稳定的纯色背景（不再使用整张皮肤文件）
+ */
+const AVATAR_COLORS = [
+  "bg-red-500",
+  "bg-orange-500",
+  "bg-amber-500",
+  "bg-lime-600",
+  "bg-green-500",
+  "bg-emerald-500",
+  "bg-teal-500",
+  "bg-cyan-500",
+  "bg-sky-500",
+  "bg-blue-500",
+  "bg-indigo-500",
+  "bg-violet-500",
+  "bg-purple-500",
+  "bg-fuchsia-500",
+  "bg-pink-500",
+  "bg-rose-500",
+];
+
+/**
+ * 根据玩家名生成稳定的纯色背景类名
+ */
+export function getAvatarColor(name: string): string {
+  if (!name) return AVATAR_COLORS[9];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+/**
+ * 从玩家名提取大写首字母作为头像文字
+ */
+export function getAvatarInitials(name: string): string {
+  if (!name) return "?";
+  return name.charAt(0).toUpperCase();
+}
+
+/**
  * 解析 Minecraft 版本号为数字数组
  * 例如 "1.20.2" → [1, 20, 2]，"1.14" → [1, 14]
  * 非标准版本号（快照、远古版等）返回 null


### PR DESCRIPTION
完成 #44 
## 使用getAvatarColor 根据玩家名哈希值生成特定头像背景颜色，替代整张皮肤文件作为头像背景
## 优化启动按钮位置，默认位于横坐标1/2，纵坐标1/3处，使得更为醒目。