### PR TITLE
feat: 对于JVM参数问题去重和修复 && moddata默认隐藏 && PCL2 兼容

### DIFF
--- a/components/launch/launch-provider.tsx
+++ b/components/launch/launch-provider.tsx
@@ -461,18 +461,22 @@ export function LaunchProvider({ children }: { children: React.ReactNode }) {
     try {
       const report = generateReport();
       const reportJson = JSON.stringify(report, null, 2);
+      const consoleLogs = logs
+        .map((l) => `[${l.timestamp}] [${l.level.toUpperCase()}] ${l.message}`)
+        .join("\n");
       return await invoke<string>("export_launch_report", {
         minecraftPath: config.minecraftPath,
         versionName: config.versionName,
         launchParameters: lastCommandArgs ?? "",
         accountType: selectedProfile?.authType ?? "offline",
         reportJson,
+        consoleLogs,
       });
     } catch (err) {
       console.error("导出启动报告失败:", err);
       throw err;
     }
-  }, [config, lastCommandArgs, selectedProfile, generateReport]);
+  }, [config, lastCommandArgs, selectedProfile, generateReport, logs]);
 
   return (
     <LaunchContext.Provider

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -39,7 +39,45 @@ interface NavItem {
 let activeNavigation: {
   transition?: ViewTransition
   controller: AbortController
+  previousPointerEvents: string
+  previousTransition: string
+  previousOpacity: string
 } | null = null
+
+const SETTLE_MS = 400
+const STABILITY_MS = 150
+const TIMEOUT_MS = 3000
+// 内容持续变动超过该时长且达到该次数时视为"流动内容"（如日志实时刷新），
+// 不再要求静止，避免导航长时间停在旧页面。
+const FLOWING_AFTER_MS = 1000
+const FLOWING_MUTATIONS = 4
+
+function abortActiveNavigation() {
+  const nav = activeNavigation
+  if (!nav) return
+  nav.controller.abort()
+  nav.transition?.skipTransition()
+  const main = document.querySelector<HTMLElement>("main")
+  if (main?.isConnected) {
+    main.style.pointerEvents = nav.previousPointerEvents
+    main.style.transition = nav.previousTransition
+    main.style.opacity = nav.previousOpacity
+  }
+  activeNavigation = null
+}
+
+// 快照前把主内容区里所有可滚动容器瞬间滚回顶部。
+// 否则旧页面快照停留在原滚动位置，而新页面从顶部开始，
+// 交叉淡入时两页内容错位重叠，产生明显的抖动/叠影。
+function scrollContentToTop(main: HTMLElement) {
+  main
+    .querySelectorAll<HTMLElement>(
+      "[class*='overflow-y-auto'], [class*='overflow-y-scroll'], [class*='overflow-auto']"
+    )
+    .forEach((el) => {
+      if (el.scrollTop > 0) el.scrollTo({ top: 0 })
+    })
+}
 
 function waitForPageContent(
   main: HTMLElement,
@@ -49,6 +87,8 @@ function waitForPageContent(
   return new Promise<void>((resolve) => {
     let settled = false
     let contentChanged = false
+    let contentChangedAt = 0
+    let changeCount = 0
     let settleTimer: number | undefined
 
     const finish = () => {
@@ -62,33 +102,55 @@ function waitForPageContent(
     }
 
     // 新页面往往先渲染出加载中指示器(spinner)再显示真实内容；
-    // 只有等指示器消失后才算内容就绪，否则淡入的是空白/加载圈，观感像"先清空再加载"。
-    const trySettle = () => {
+    // 内容尚未变化前保持等待，避免淡入的是空白/加载圈。
+    // 内容一旦变化就按"保持稳定"收尾，忽略残留的小型 spinner
+    // （如按钮内的加载图标），否则会被它们无限期阻塞。
+    const trySettle = (now: number) => {
       if (!contentChanged) return
-      if (main.querySelector(".animate-spin")) {
-        // 出现新的加载指示器时取消已安排的收尾，继续等待。
-        window.clearTimeout(settleTimer)
-        settleTimer = undefined
+      if (!contentChangedAt) contentChangedAt = now
+      // 内容持续流动（日志实时刷新等）超过阈值时不再等待静止。
+      if (
+        now - contentChangedAt > FLOWING_AFTER_MS &&
+        changeCount >= FLOWING_MUTATIONS
+      ) {
+        finish()
         return
       }
-      if (settleTimer !== undefined) return
-      // 内容更新且无加载指示器后，稍等让入场动画稳定几帧再交叉淡入。
-      settleTimer = window.setTimeout(finish, 100)
+      // 收尾时刻 = 首次内容变化的固定窗口(覆盖新页面入场动画，避免快照截在
+      // 动画中途导致淡入结束时内容跳动) 与 最近一次变动后的短暂静止窗口
+      // (吸收异步数据波) 的较晚者。入场动画期间的高频样式变动不会无限叠加等待。
+      const deadline = Math.max(
+        contentChangedAt + SETTLE_MS,
+        now + STABILITY_MS
+      )
+      window.clearTimeout(settleTimer)
+      settleTimer = window.setTimeout(finish, Math.max(0, deadline - performance.now()))
     }
 
+    // 用 rAF 批量合并同一帧内的多次 DOM 变动，
+    // 避免实时日志等高频更新场景下逐条重算 innerText 卡顿主线程。
+    let pending = false
     const observer = new MutationObserver(() => {
-      if (main.innerText === previousText) return
-      contentChanged = true
-      trySettle()
+      if (pending) return
+      pending = true
+      requestAnimationFrame(() => {
+        pending = false
+        if (settled) return
+        if (main.innerText === previousText) return
+        changeCount += 1
+        contentChanged = true
+        trySettle(performance.now())
+      })
     })
 
     observer.observe(main, {
       childList: true,
       subtree: true,
       characterData: true,
+      attributes: true,
     })
 
-    const timeoutTimer = window.setTimeout(finish, 1200)
+    const timeoutTimer = window.setTimeout(finish, TIMEOUT_MS)
 
     if (signal.aborted) {
       finish()
@@ -145,13 +207,25 @@ function NavButton({ item, isActive, isExactActive }: { item: NavItem; isActive:
 
     const previousText = main.innerText
 
-    activeNavigation?.controller.abort()
-    activeNavigation?.transition?.skipTransition()
+    abortActiveNavigation()
 
     const controller = new AbortController()
 
+    // 尊重系统减弱动效设置：直接切换，不做任何过渡动画。
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      router.push(item.href)
+      return
+    }
+
     const startViewTransition = document.startViewTransition?.bind(document)
     if (startViewTransition) {
+      // 快照前把内容瞬间滚回顶部，保证新旧两页从同一滚动位置开始交叉淡入，
+      // 否则旧快照停留在滚动处、新页面从顶部开始，错位叠影会表现为界面抽搐。
+      scrollContentToTop(main)
+
+      const previousPointerEvents = main.style.pointerEvents
+      main.style.pointerEvents = "none"
+
       const transition = startViewTransition(async () => {
         const contentReady = waitForPageContent(
           main,
@@ -162,23 +236,40 @@ function NavButton({ item, isActive, isExactActive }: { item: NavItem; isActive:
         await contentReady
       })
 
-      const navigation = { transition, controller }
+      const navigation = {
+        transition,
+        controller,
+        previousPointerEvents,
+        previousTransition: "",
+        previousOpacity: "",
+      }
       activeNavigation = navigation
 
       void transition.finished
         .catch(() => undefined)
         .finally(() => {
-          if (activeNavigation === navigation) activeNavigation = null
+          if (activeNavigation !== navigation) return
+          activeNavigation = null
+          if (main.isConnected) {
+            main.style.pointerEvents = previousPointerEvents
+          }
         })
       return
     }
 
     // 无 View Transitions 支持（旧版 WebKitGTK）：
     // 退化为 CSS 过渡做等价的淡出 → 等待内容就绪 → 淡入。
-    const navigation = { controller }
-    activeNavigation = navigation
     const previousTransition = main.style.transition
     const previousPointerEvents = main.style.pointerEvents
+    const previousOpacity = main.style.opacity
+
+    const navigation = {
+      controller,
+      previousPointerEvents,
+      previousTransition,
+      previousOpacity,
+    }
+    activeNavigation = navigation
 
     main.style.pointerEvents = "none"
     main.style.transition = "opacity 0.14s ease-out"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -37,13 +37,14 @@ interface NavItem {
 }
 
 let activeNavigation: {
-  transition?: ViewTransition
   controller: AbortController
   previousPointerEvents: string
   previousTransition: string
   previousOpacity: string
 } | null = null
 
+const FADE_OUT_MS = 140
+const FADE_IN_MS = 240
 const SETTLE_MS = 400
 const STABILITY_MS = 150
 const TIMEOUT_MS = 3000
@@ -56,7 +57,6 @@ function abortActiveNavigation() {
   const nav = activeNavigation
   if (!nav) return
   nav.controller.abort()
-  nav.transition?.skipTransition()
   const main = document.querySelector<HTMLElement>("main")
   if (main?.isConnected) {
     main.style.pointerEvents = nav.previousPointerEvents
@@ -66,22 +66,19 @@ function abortActiveNavigation() {
   activeNavigation = null
 }
 
-// 快照前把主内容区里所有可滚动容器瞬间滚回顶部。
-// 否则旧页面快照停留在原滚动位置，而新页面从顶部开始，
-// 交叉淡入时两页内容错位重叠，产生明显的抖动/叠影。
-function scrollContentToTop(main: HTMLElement) {
-  main
-    .querySelectorAll<HTMLElement>(
-      "[class*='overflow-y-auto'], [class*='overflow-y-scroll'], [class*='overflow-auto']"
-    )
-    .forEach((el) => {
-      if (el.scrollTop > 0) el.scrollTo({ top: 0 })
-    })
+// 归一化路径（去掉结尾斜杠），用于判断路由是否已切换到位。
+function normalizePathname(path: string) {
+  let normalized = path
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1)
+  }
+  return normalized
 }
 
 function waitForPageContent(
   main: HTMLElement,
   previousText: string,
+  targetPathname: string,
   signal: AbortSignal
 ) {
   return new Promise<void>((resolve) => {
@@ -116,8 +113,8 @@ function waitForPageContent(
         finish()
         return
       }
-      // 收尾时刻 = 首次内容变化的固定窗口(覆盖新页面入场动画，避免快照截在
-      // 动画中途导致淡入结束时内容跳动) 与 最近一次变动后的短暂静止窗口
+      // 收尾时刻 = 首次内容变化的固定窗口(覆盖新页面入场动画，避免淡入
+      // 截在动画中途导致淡入结束后内容跳动) 与 最近一次变动后的短暂静止窗口
       // (吸收异步数据波) 的较晚者。入场动画期间的高频样式变动不会无限叠加等待。
       const deadline = Math.max(
         contentChangedAt + SETTLE_MS,
@@ -136,6 +133,10 @@ function waitForPageContent(
       requestAnimationFrame(() => {
         pending = false
         if (settled) return
+        // 路由尚未切换到目标页面时忽略所有变动：
+        // 路由切换期间旧页面自身的异步更新（下载进度、日志等）也会触发
+        // MutationObserver，不区分会导致"新页面已就绪"的误判，淡入的仍是旧页面。
+        if (normalizePathname(window.location.pathname) !== targetPathname) return
         if (main.innerText === previousText) return
         changeCount += 1
         contentChanged = true
@@ -217,68 +218,36 @@ function NavButton({ item, isActive, isExactActive }: { item: NavItem; isActive:
       return
     }
 
-    const startViewTransition = document.startViewTransition?.bind(document)
-    if (startViewTransition) {
-      // 快照前把内容瞬间滚回顶部，保证新旧两页从同一滚动位置开始交叉淡入，
-      // 否则旧快照停留在滚动处、新页面从顶部开始，错位叠影会表现为界面抽搐。
-      scrollContentToTop(main)
-
-      const previousPointerEvents = main.style.pointerEvents
-      main.style.pointerEvents = "none"
-
-      const transition = startViewTransition(async () => {
-        const contentReady = waitForPageContent(
-          main,
-          previousText,
-          controller.signal
-        )
-        router.push(item.href)
-        await contentReady
-      })
-
-      const navigation = {
-        transition,
-        controller,
-        previousPointerEvents,
-        previousTransition: "",
-        previousOpacity: "",
-      }
-      activeNavigation = navigation
-
-      void transition.finished
-        .catch(() => undefined)
-        .finally(() => {
-          if (activeNavigation !== navigation) return
-          activeNavigation = null
-          if (main.isConnected) {
-            main.style.pointerEvents = previousPointerEvents
-          }
-        })
-      return
-    }
-
-    // 无 View Transitions 支持（旧版 WebKitGTK）：
-    // 退化为 CSS 过渡做等价的淡出 → 等待内容就绪 → 淡入。
+    // 统一采用"旧页淡出 → 路由切换 → 新页内容就绪后淡入"的确定性时序，
+    // 不再使用 View Transitions 交叉淡入：
+    // 旧页彻底不可见之后新页才出现，两者永不同屏，因此不会出现
+    // 旧快照叠在新页面之上造成的"旧页闪现"，也不存在滚动位置错位抖动。
     const previousTransition = main.style.transition
     const previousPointerEvents = main.style.pointerEvents
     const previousOpacity = main.style.opacity
 
     const navigation = {
       controller,
-      previousPointerEvents,
       previousTransition,
+      previousPointerEvents,
       previousOpacity,
     }
     activeNavigation = navigation
 
     main.style.pointerEvents = "none"
-    main.style.transition = "opacity 0.14s ease-out"
+    main.style.transition = `opacity ${FADE_OUT_MS}ms ease-out`
     main.style.opacity = "0"
 
+    const targetPathname = normalizePathname(item.href)
+
     window.setTimeout(async () => {
+      // 若在此期间已被新的导航中断（abort），不再执行本次路由切换。
+      if (controller.signal.aborted) return
+
       const contentReady = waitForPageContent(
         main,
         previousText,
+        targetPathname,
         controller.signal
       )
       router.push(item.href)
@@ -287,17 +256,18 @@ function NavButton({ item, isActive, isExactActive }: { item: NavItem; isActive:
       if (activeNavigation !== navigation) return
       requestAnimationFrame(() => {
         if (!main.isConnected) return
-        main.style.transition = "opacity 0.24s ease-out"
+        main.style.transition = `opacity ${FADE_IN_MS}ms ease-out`
         main.style.opacity = "1"
         window.setTimeout(() => {
           if (main.isConnected) {
             main.style.transition = previousTransition
             main.style.pointerEvents = previousPointerEvents
+            main.style.opacity = previousOpacity
           }
           if (activeNavigation === navigation) activeNavigation = null
-        }, 260)
+        }, FADE_IN_MS + 20)
       })
-    }, 150)
+    }, FADE_OUT_MS + 20)
   }
 
   return (

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,13 +4,7 @@ packages:
   - "examples/themes/*"
 
 allowBuilds:
-  msw: false
+  esbuild: true
+  msw: true
   sharp: false
   unrs-resolver: false
-
-ignoredBuiltDependencies:
-  - sharp
-  - unrs-resolver
-
-onlyBuiltDependencies:
-  - msw

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3705,6 +3705,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
+ "dirs",
  "env_logger",
  "fastnbt",
  "flate2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "dirs",
+ "encoding_rs",
  "env_logger",
  "fastnbt",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ sysinfo = "0.33"
 tao = "0.35.3"
 urlencoding = "2.1"
 dirs = "6"
+encoding_rs = "0.8"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,7 @@ flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 sysinfo = "0.33"
 tao = "0.35.3"
 urlencoding = "2.1"
+dirs = "6"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6.2"

--- a/src-tauri/src/handler/chinese_search.rs
+++ b/src-tauri/src/handler/chinese_search.rs
@@ -11,8 +11,20 @@ fn get_moddata_connection() -> &'static Mutex<Option<Connection>> {
     MDDATA_CONN.get_or_init(|| Mutex::new(None))
 }
 
-/// 获取 moddata.db 的目标路径（可执行文件同目录）
+/// 获取 moddata.db 的隐藏存放目录（各平台用户数据目录，默认均不直接暴露）：
+///   Linux:   $XDG_DATA_HOME/rtlauncher 或 ~/.local/share/rtlauncher（.local 为隐藏目录）
+///   macOS:   ~/Library/Application Support/rtlauncher（Library 在 Finder 中默认隐藏）
+///   Windows: %APPDATA%\rtlauncher（AppData 目录默认隐藏）
+fn get_moddata_data_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|dir| dir.join("rtlauncher"))
+}
+
+/// 获取 moddata.db 的目标路径（优先存放于隐藏的用户数据目录）
 fn get_moddata_target_path() -> PathBuf {
+    if let Some(dir) = get_moddata_data_dir() {
+        return dir.join("moddata.db");
+    }
+    // 兜底：无用户数据目录时退回可执行文件同目录
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             return dir.join("moddata.db");
@@ -23,18 +35,27 @@ fn get_moddata_target_path() -> PathBuf {
 
 /// 获取 moddata.db 的文件路径
 /// 查找顺序：
-///   1. 程序当前目录下的 moddata.db
-///   2. 程序可执行文件同目录下的 moddata.db
-///   3. 上层目录的 moddata.db（开发环境）
+///   1. 隐藏的用户数据目录（新版本默认位置）
+///   2. 程序当前目录下的 moddata.db（旧版本遗留）
+///   3. 程序可执行文件同目录下的 moddata.db（旧版本遗留）
+///   4. 上层目录的 moddata.db（开发环境）
 fn resolve_moddata_path() -> Option<PathBuf> {
-    // 1) 当前工作目录
+    // 1) 隐藏的用户数据目录
+    if let Some(dir) = get_moddata_data_dir() {
+        let p = dir.join("moddata.db");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    // 2) 当前工作目录（旧版本遗留）
     let cwd = PathBuf::from(".");
     let p1 = cwd.join("moddata.db");
     if p1.exists() {
         return Some(p1);
     }
 
-    // 2) 可执行文件目录
+    // 3) 可执行文件目录（旧版本遗留）
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             let p = dir.join("moddata.db");
@@ -44,13 +65,13 @@ fn resolve_moddata_path() -> Option<PathBuf> {
         }
     }
 
-    // 3) 上层目录（开发环境，项目根）
+    // 4) 上层目录（开发环境，项目根）
     let p3 = cwd.join("..").join("moddata.db");
     if p3.exists() {
         return Some(p3);
     }
 
-    // 4) src-tauri 上层
+    // 5) src-tauri 上层
     let p4 = cwd.join("..").join("..").join("moddata.db");
     if p4.exists() {
         return Some(p4);
@@ -59,32 +80,70 @@ fn resolve_moddata_path() -> Option<PathBuf> {
     None
 }
 
+/// 远程数据库的候选下载地址（按顺序尝试，成功后即停止）
+/// 新源可在此追加：GitHub 优先，GitHub 不可达或资源不存在时回退到 GitCode
+const MODDATA_DOWNLOAD_URLS: &[&str] = &[
+    // 首选：GitHub（需在 https://github.com/cqw-acq/RTLauncher_new 的
+    //       "工具" 标签发布 moddata.db 资源后才生效）
+    "https://github.com/cqw-acq/RTLauncher_new/releases/download/%E5%B7%A5%E5%85%B7/moddata.db",
+    // 备选：GitCode（GitHub 无法访问时的镜像）
+    "https://gitcode.com/bubulaladdi/RTLauncher/releases/download/%E5%B7%A5%E5%85%B7/moddata.db",
+];
+
 /// 从远程下载 moddata.db
 fn download_moddata_db() -> Result<PathBuf, String> {
-    let url = "https://gitcode.com/bubulaladdi/RTLauncher/releases/download/%E5%B7%A5%E5%85%B7/moddata.db";
     let target_path = get_moddata_target_path();
-    
-    println!("[moddata] 正在下载数据库文件: {}", url);
-    
-    let response = reqwest::blocking::get(url).map_err(|e| format!("下载数据库失败: {}", e))?;
-    
-    if !response.status().is_success() {
-        return Err(format!("下载数据库失败，HTTP状态码: {}", response.status()));
-    }
-    
-    let bytes = response
-        .bytes()
-        .map_err(|e| format!("读取下载内容失败: {}", e))?;
-    
+
     // 确保目标目录存在
     if let Some(parent) = target_path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("创建目录失败: {}", e))?;
     }
-    
-    fs::write(&target_path, bytes).map_err(|e| format!("写入数据库文件失败: {}", e))?;
-    
-    println!("[moddata] 数据库文件已下载到: {}", target_path.display());
-    Ok(target_path)
+
+    let client = reqwest::blocking::Client::builder()
+        // GitHub 无法访问时连接会挂起，限制连接超时以便快速回退到下一源
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))?;
+
+    let mut last_error: Option<String> = None;
+    for url in MODDATA_DOWNLOAD_URLS {
+        println!("[moddata] 正在下载数据库文件: {}", url);
+        match download_from_url(&client, url, &target_path) {
+            Ok(()) => {
+                println!("[moddata] 数据库文件已下载到: {}", target_path.display());
+                return Ok(target_path);
+            }
+            Err(e) => {
+                println!("[moddata] 从 {} 下载失败: {}", url, e);
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| "所有下载源均不可用".to_string()))
+}
+
+fn download_from_url(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    target_path: &PathBuf,
+) -> Result<(), String> {
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|e| format!("网络请求失败: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("HTTP状态码: {}", response.status()));
+    }
+
+    let bytes = response
+        .bytes()
+        .map_err(|e| format!("读取下载内容失败: {}", e))?;
+
+    fs::write(target_path, bytes).map_err(|e| format!("写入数据库文件失败: {}", e))?;
+    Ok(())
 }
 
 /// 打开 moddata 数据库连接（首次调用时建立，之后复用）

--- a/src-tauri/src/handler/config.rs
+++ b/src-tauri/src/handler/config.rs
@@ -158,6 +158,104 @@ fn detect_hmcl_minecraft_paths() -> Vec<String> {
     paths
 }
 
+/// 从 PCL2 配置文件中提取游戏目录
+/// PCL2 便携模式配置位于 <启动器目录>/PCL/launcher_settings.ini，
+/// 其中 CustomGameFolders= 保存了用户添加的游戏文件夹列表（分号分隔，GBK 编码）
+fn detect_pcl2_minecraft_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+
+    // 收集可能的 PCL2 启动器目录
+    let mut pcl2_roots = Vec::new();
+
+    // 便携模式：当前目录 / 可执行文件同目录
+    pcl2_roots.push(PathBuf::from("."));
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            pcl2_roots.push(dir.to_path_buf());
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            pcl2_roots.push(PathBuf::from(appdata).join("PCL"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            pcl2_roots.push(PathBuf::from(home).join(".local").join("share").join("PCL"));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            pcl2_roots.push(PathBuf::from(home).join("Library").join("Application Support").join("PCL"));
+        }
+    }
+
+    for root in pcl2_roots {
+        // 便携模式：<root>/PCL/launcher_settings.ini
+        let config_file = root.join("PCL").join("launcher_settings.ini");
+        if config_file.exists() {
+            if let Some(folders) = parse_pcl2_custom_game_folders(&config_file) {
+                paths.extend(folders);
+            }
+            // 便携模式下默认游戏目录为 <root>/.minecraft
+            let default_game_dir = root.join(".minecraft");
+            if default_game_dir.is_dir() {
+                paths.push(default_game_dir.to_string_lossy().into_owned());
+            }
+        } else {
+            // 非便携模式：<root>/launcher_settings.ini
+            let alt = root.join("launcher_settings.ini");
+            if alt.exists() {
+                if let Some(folders) = parse_pcl2_custom_game_folders(&alt) {
+                    paths.extend(folders);
+                }
+            }
+        }
+    }
+
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// 解析 PCL2 launcher_settings.ini 中的自定义游戏文件夹列表
+/// 配置为 GBK 编码，先尝试 UTF-8，失败时用 GBK 解码
+fn parse_pcl2_custom_game_folders(config_file: &Path) -> Option<Vec<String>> {
+    let bytes = fs::read(config_file).ok()?;
+    let content = String::from_utf8(bytes.clone()).unwrap_or_else(|_| {
+        let (decoded, _, _) = encoding_rs::GBK.decode(&bytes);
+        decoded.into_owned()
+    });
+
+    let mut folders = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('[') || line.starts_with(';') || line.starts_with('#') {
+            continue;
+        }
+        let Some(eq) = line.find('=') else { continue };
+        let key = line[..eq].trim();
+        if !key.eq_ignore_ascii_case("CustomGameFolders") {
+            continue;
+        }
+        let value = line[eq + 1..].trim();
+        for folder in value.split(';') {
+            let folder = folder.trim();
+            if !folder.is_empty() {
+                folders.push(folder.to_string());
+            }
+        }
+        break;
+    }
+    Some(folders)
+}
+
 /// 智能判断目录是否为有效的 Minecraft 游戏目录
 /// 通过检查关键文件和目录结构来区分 .minecraft 和 .hmcl
 fn is_valid_minecraft_directory(path: &Path) -> bool {
@@ -274,12 +372,18 @@ pub fn get_launcher_paths_config() -> LauncherPathsConfig {
                     cfg.minecraft_paths = dedup;
                 }
                 
-                // 从 HMCL 配置文件检测游戏目录并添加到列表
+                // 从 HMCL / PCL2 配置文件检测游戏目录并添加到列表
                 let hmcl_paths = detect_hmcl_minecraft_paths();
                 for hmcl_path in hmcl_paths {
                     // 只添加通过验证的 Minecraft 目录，避免误判 .hmcl 目录
                     if is_valid_minecraft_directory(Path::new(&hmcl_path)) && !cfg.minecraft_paths.contains(&hmcl_path) {
                         cfg.minecraft_paths.push(hmcl_path);
+                    }
+                }
+                let pcl2_paths = detect_pcl2_minecraft_paths();
+                for pcl2_path in pcl2_paths {
+                    if is_valid_minecraft_directory(Path::new(&pcl2_path)) && !cfg.minecraft_paths.contains(&pcl2_path) {
+                        cfg.minecraft_paths.push(pcl2_path);
                     }
                 }
                 
@@ -288,12 +392,18 @@ pub fn get_launcher_paths_config() -> LauncherPathsConfig {
             Err(_) => def,
         }
     } else {
-        // 即使配置文件不存在，也尝试从 HMCL 检测路径
+        // 即使配置文件不存在，也尝试从 HMCL / PCL2 检测路径
         let mut cfg = def.clone();
         let hmcl_paths = detect_hmcl_minecraft_paths();
         for hmcl_path in hmcl_paths {
             if is_valid_minecraft_directory(Path::new(&hmcl_path)) && !cfg.minecraft_paths.contains(&hmcl_path) {
                 cfg.minecraft_paths.push(hmcl_path);
+            }
+        }
+        let pcl2_paths = detect_pcl2_minecraft_paths();
+        for pcl2_path in pcl2_paths {
+            if is_valid_minecraft_directory(Path::new(&pcl2_path)) && !cfg.minecraft_paths.contains(&pcl2_path) {
+                cfg.minecraft_paths.push(pcl2_path);
             }
         }
         cfg

--- a/src-tauri/src/handler/diagnostics.rs
+++ b/src-tauri/src/handler/diagnostics.rs
@@ -1658,6 +1658,7 @@ pub async fn export_launch_report(
     launch_parameters: String,
     account_type: String,
     report_json: String,
+    console_logs: String,
 ) -> Result<String, String> {
     let mc_path = PathBuf::from(&minecraft_path);
 
@@ -1705,6 +1706,16 @@ pub async fn export_launch_report(
             zip.write_all(log_content.as_bytes())
                 .map_err(|e| format!("写入latest.log失败: {}", e))?;
         }
+    }
+
+    if !console_logs.trim().is_empty() {
+        zip.start_file(
+            "console.log",
+            FileOptions::default().compression_method(CompressionMethod::Deflated),
+        )
+        .map_err(|e| format!("添加console.log失败: {}", e))?;
+        zip.write_all(console_logs.as_bytes())
+            .map_err(|e| format!("写入console.log失败: {}", e))?;
     }
 
     let result = zip.finish();

--- a/src-tauri/src/handler/launcher.rs
+++ b/src-tauri/src/handler/launcher.rs
@@ -287,6 +287,45 @@ mod tests {
     }
 
     #[test]
+    fn keeps_loader_add_opens_for_named_modules() {
+        // --add-opens/--add-exports 可多次出现且目标模块不同，即使固定参数
+        // 已带 --add-opens（ALL-UNNAMED 或 securejarhandler），loader 的
+        // 具名模块开放也必须保留，否则 securejarhandler 类初始化崩溃。
+        let mut args = vec![
+            "--add-opens".to_string(),
+            "java.base/java.lang.invoke=cpw.mods.securejarhandler".to_string(),
+            "-p".to_string(),
+            "module-path".to_string(),
+        ];
+        let loader_args = vec![
+            "--add-modules".to_string(),
+            "ALL-MODULE-PATH".to_string(),
+            "--add-opens".to_string(),
+            "java.base/java.util.jar=cpw.mods.securejarhandler".to_string(),
+            "--add-exports".to_string(),
+            "java.base/sun.security.util=cpw.mods.securejarhandler".to_string(),
+        ];
+
+        append_loader_jvm_args(&mut args, &loader_args);
+
+        assert_eq!(
+            args,
+            vec![
+                "--add-opens",
+                "java.base/java.lang.invoke=cpw.mods.securejarhandler",
+                "-p",
+                "module-path",
+                "--add-modules",
+                "ALL-MODULE-PATH",
+                "--add-opens",
+                "java.base/java.util.jar=cpw.mods.securejarhandler",
+                "--add-exports",
+                "java.base/sun.security.util=cpw.mods.securejarhandler",
+            ]
+        );
+    }
+
+    #[test]
     fn skips_loader_args_whose_key_is_already_effective() {
         // 与 keeps_an_existing_effective_module_path 不同，这里连 -Xss1M、
         // -Djava.library.path 这类普通键也要去重，否则同一参数被拼接多次

--- a/src-tauri/src/handler/launcher.rs
+++ b/src-tauri/src/handler/launcher.rs
@@ -198,7 +198,10 @@ pub fn launch_game(
 #[cfg(test)]
 mod tests {
     use super::{
-        arguments::{append_loader_jvm_args, dedup_path_list, launcher_rules_allow},
+        arguments::{
+            append_loader_jvm_args, dedup_path_list, launcher_rules_allow, merge_loader_game_args,
+            merge_version_jvm_args,
+        },
         identity::launch_auth_identity,
         java_runtime::is_plausible_minecraft_version,
         memory::{safe_max_memory_mb, SafeMemoryLimit},
@@ -281,6 +284,174 @@ mod tests {
         );
 
         assert_eq!(args, vec!["-p", "effective-module-path"]);
+    }
+
+    #[test]
+    fn skips_loader_args_whose_key_is_already_effective() {
+        // 与 keeps_an_existing_effective_module_path 不同，这里连 -Xss1M、
+        // -Djava.library.path 这类普通键也要去重，否则同一参数被拼接多次
+        // （固定参数、version json jvm 参数、loader 参数三处都会出现）。
+        let mut args = vec![
+            "-Xss1M".to_string(),
+            "-Djava.library.path=/minecraft/natives".to_string(),
+            "-p".to_string(),
+            "effective-module-path".to_string(),
+        ];
+        let loader_args = vec![
+            "-Xss1M".to_string(),
+            "-Djava.library.path=/other/natives".to_string(),
+            "-Dminecraft.launcher.brand=RTLauncher".to_string(),
+            "-p".to_string(),
+            "loader-module-path".to_string(),
+        ];
+
+        append_loader_jvm_args(&mut args, &loader_args);
+
+        // -Xss1M 与 -Djava.library.path（-D 前缀键去重）都被跳过，
+        // 保留已生效的值；只有新键 -Dminecraft.launcher.brand 被补入。
+        assert_eq!(
+            args,
+            vec![
+                "-Xss1M",
+                "-Djava.library.path=/minecraft/natives",
+                "-p",
+                "effective-module-path",
+                "-Dminecraft.launcher.brand=RTLauncher",
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_version_jvm_args_skips_placeholder_garbage_by_key() {
+        // version json 的 jvm 参数里 -Djava.library.path 的占位符替换结果
+        // 是 -Djava.library.path={}（垃圾值），而 loader 参数里是完整路径。
+        // 必须按键（= 之前的部分）去重，把垃圾值跳过去；
+        // 即使 loader 里没有同名键（如 -Djna.tmpdir），垃圾值也直接丢弃。
+        let mut args = Vec::new();
+        let jvm_args_from_version = vec![
+            "-Djava.library.path={}".to_string(),
+            "-Djna.tmpdir={}".to_string(),
+            "-Dminecraft.launcher.brand=RTLauncher".to_string(),
+            "-cp".to_string(),
+            "version-classpath".to_string(),
+        ];
+        let extra_before_cp = vec![
+            "-Djava.library.path=C:/minecraft/versions/inst/inst-natives".to_string(),
+        ];
+
+        merge_version_jvm_args(&mut args, &jvm_args_from_version, &extra_before_cp);
+
+        // -Djava.library.path={} 因键已存在被跳过，-Djna.tmpdir={} 因垃圾值被
+        // 丢弃；loader 没有的合法键 -Dminecraft.launcher.brand 被加入；
+        // -cp 作为关键参数始终补入
+        assert_eq!(
+            args,
+            vec![
+                "-Dminecraft.launcher.brand=RTLauncher".to_string(),
+                "-cp".to_string(),
+                "version-classpath".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_version_jvm_args_keeps_absent_keys() {
+        // loader 里没有的键（如 -Xmn768m）仍然会被加入
+        let mut args = Vec::new();
+        let jvm_args_from_version = vec!["-Xmn768m".to_string()];
+        let extra_before_cp = vec!["-Dminecraft.launcher.brand=RTLauncher".to_string()];
+
+        merge_version_jvm_args(&mut args, &jvm_args_from_version, &extra_before_cp);
+
+        assert_eq!(args, vec!["-Xmn768m".to_string()]);
+    }
+
+    #[test]
+    fn merge_loader_game_args_does_not_append_values_of_existing_keys() {
+        // PCL CE 生成的 NeoForge 实例 json 的 game 参数携带
+        // --fml.neoForgeVersion 21.1.238 等字面量；这些 --key 已存在于
+        // 原版/实例 json 参数中，此时只能整对跳过，否则 21.1.238 等裸值
+        // 会被重复拼到命令尾部（报告中命令末尾出现的大量重复拼接）。
+        let mut game_args = vec![
+            "--launchTarget".to_string(),
+            "forgeclient".to_string(),
+            "--width".to_string(),
+            "873".to_string(),
+            "--height".to_string(),
+            "486".to_string(),
+            "--fml.forgeVersion".to_string(),
+            "21.1.238".to_string(),
+            "--fml.fmlVersion".to_string(),
+            "4.0.43".to_string(),
+            "--fml.mcVersion".to_string(),
+            "1.21.1".to_string(),
+            "--fml.neoFormVersion".to_string(),
+            "20240808.144430".to_string(),
+        ];
+        let extra_after_cp = vec![
+            "--fml.forgeVersion".to_string(),
+            "21.1.238".to_string(),
+            "--fml.fmlVersion".to_string(),
+            "4.0.43".to_string(),
+            "--fml.mcVersion".to_string(),
+            "1.21.1".to_string(),
+            "--fml.neoFormVersion".to_string(),
+            "20240808.144430".to_string(),
+            "--launchTarget".to_string(),
+            "forgeclient".to_string(),
+            "--fml.legacyCPVersion".to_string(),
+            "21.1.238".to_string(),
+        ];
+
+        merge_loader_game_args(&mut game_args, &extra_after_cp);
+
+        // 已有键整对跳过（不再产生 21.1.238 4.0.43 ... forgeclient 尾部垃圾）；
+        // 只有全新的 --fml.legacyCPVersion 连值一起补入
+        assert_eq!(
+            game_args,
+            vec![
+                "--launchTarget",
+                "forgeclient",
+                "--width",
+                "873",
+                "--height",
+                "486",
+                "--fml.forgeVersion",
+                "21.1.238",
+                "--fml.fmlVersion",
+                "4.0.43",
+                "--fml.mcVersion",
+                "1.21.1",
+                "--fml.neoFormVersion",
+                "20240808.144430",
+                "--fml.legacyCPVersion",
+                "21.1.238",
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_loader_game_args_keeps_new_key_and_bare_value() {
+        // 全新的 --key 及其值、以及不属于任何已存在 --key 的裸值仍被保留
+        let mut game_args = vec!["--width".to_string(), "873".to_string()];
+        let extra_after_cp = vec![
+            "--new-key".to_string(),
+            "new-value".to_string(),
+            "bare-value".to_string(),
+        ];
+
+        merge_loader_game_args(&mut game_args, &extra_after_cp);
+
+        assert_eq!(
+            game_args,
+            vec![
+                "--width",
+                "873",
+                "--new-key",
+                "new-value",
+                "bare-value",
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/handler/launcher.rs
+++ b/src-tauri/src/handler/launcher.rs
@@ -198,13 +198,47 @@ pub fn launch_game(
 #[cfg(test)]
 mod tests {
     use super::{
-        arguments::{append_loader_jvm_args, launcher_rules_allow},
+        arguments::{append_loader_jvm_args, dedup_path_list, launcher_rules_allow},
         identity::launch_auth_identity,
         java_runtime::is_plausible_minecraft_version,
         memory::{safe_max_memory_mb, SafeMemoryLimit},
         process::display_exit_code,
     };
     use serde_json::json;
+
+    #[test]
+    fn removes_duplicate_jars_from_a_loader_classpath() {
+        // PCL CE 生成的 NeoForge 实例 json 会携带字面量 -cp，其中同一
+        // jar 可能因原版库与加载器库重复拼接而出现两次。
+        let mut args = Vec::new();
+        let classpath = format!(
+            "{p}{p}{p2}{p3}",
+            p = "C:/Users/Hill233/AppData/Roaming/.minecraft/libraries/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar;",
+            p2 = "C:/Users/Hill233/AppData/Roaming/.minecraft/libraries/com/mojang/logging/1.2.7/logging-1.2.7.jar;",
+            p3 = "C:/Users/Hill233/AppData/Roaming/.minecraft/libraries/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar"
+        );
+
+        append_loader_jvm_args(&mut args, &["-cp".to_string(), classpath.clone()]);
+
+        let idx = args.iter().position(|a| a == "-cp").unwrap();
+        let value = &args[idx + 1];
+        assert_eq!(value.matches("gson-2.10.1.jar").count(), 1);
+        assert_eq!(value.matches("logging-1.2.7.jar").count(), 1);
+    }
+
+    #[test]
+    fn dedup_path_list_keeps_order_and_case_insensitive_duplicates() {
+        let deduped = dedup_path_list(
+            "C:/a.jar;C:/b.jar;c:/A.JAR;C:/c.jar;C:/b.jar",
+        );
+        assert_eq!(deduped, "C:/a.jar;C:/b.jar;C:/c.jar");
+    }
+
+    #[test]
+    fn dedup_path_list_handles_unix_style_separator() {
+        let deduped = dedup_path_list("/l/a.jar:/l/b.jar:/l/a.jar");
+        assert_eq!(deduped, "/l/a.jar:/l/b.jar");
+    }
 
     #[test]
     fn keeps_loader_module_path_when_vanilla_supplies_classpath() {

--- a/src-tauri/src/handler/launcher/arguments.rs
+++ b/src-tauri/src/handler/launcher/arguments.rs
@@ -78,6 +78,29 @@ fn shell_split(input: &str) -> Vec<String> {
     tokens
 }
 
+/// 对 -cp / -p 等路径列表参数做去重（保留原有顺序）。
+///
+/// 部分启动器（如 PCL CE）生成的 version.json 会把父版本库与加载器库
+/// 简单拼接而不去重，导致同一个 jar 在 classpath 中出现多次。重复的
+/// 路径会让 NeoForge/Forge 的 UnionFileSystem 在启动阶段直接抛出
+/// "Duplicate key ... (attempted merging values ...)" 并以退出码 1 退出。
+pub(super) fn dedup_path_list(value: &str) -> String {
+    let sep = if value.contains(';') { ';' } else { ':' };
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut parts: Vec<&str> = Vec::new();
+    for piece in value.split(sep) {
+        let piece = piece.trim();
+        if piece.is_empty() {
+            continue;
+        }
+        // Windows 文件系统不区分大小写，统一转小写后去重
+        if seen.insert(piece.to_lowercase()) {
+            parts.push(piece);
+        }
+    }
+    parts.join(&sep.to_string())
+}
+
 /// Add JVM arguments read from a separate loader JSON.
 ///
 /// A selected instance may use the vanilla JSON as `version_name` and a Forge
@@ -100,7 +123,13 @@ pub(super) fn append_loader_jvm_args(args: &mut Vec<String>, loader_args: &[Stri
         if !already_present {
             args.push(key.clone());
             if has_value {
-                args.push(loader_args[index + 1].clone());
+                let value = &loader_args[index + 1];
+                if is_path_key {
+                    // PCL 等启动器写入的 classpath 可能包含重复 jar，去重后再转发
+                    args.push(dedup_path_list(value));
+                } else {
+                    args.push(value.clone());
+                }
             }
         }
 
@@ -1528,6 +1557,13 @@ pub(super) fn build_jvm_arguments_inner(
         println!("使用模块系统，跳过添加游戏JAR到classpath");
     }
 
+    // ===== 关键修复：classpath 去重 =====
+    // 部分启动器生成的 version.json 的 libraries 列表本身含重复项（例如
+    // PCL 的 NeoForge 实例把原版库与加载器库重复拼接），重复 jar 会令
+    // NeoForge 的 UnionFileSystem 抛出 "Duplicate key" 而启动失败，这里统一去重。
+    let mut seen_classpath: HashSet<String> = HashSet::new();
+    class_path_entries.retain(|p| seen_classpath.insert(p.to_lowercase()));
+
     // ===== 预构建 class_path（用于 ${classpath} 占位符替换）=====
     // 必须在 jvm_args_from_version 之前构建，因为 jvm_args_from_version 的 replace_placeholders
     // 会使用这个变量。
@@ -2061,28 +2097,32 @@ pub(super) fn build_jvm_arguments_inner(
                 continue;
             }
 
-            args.push(p.clone());
-            if has_value {
-                // 对于 -p/--module-path，额外检查其中引用的 JAR 是否存在
-                let value = &jvm_args_from_version[i + 1];
-                if is_module_or_class_path_key {
-                    debug!("[HMCL 模式] 使用 Forge 参数: {} 值长度: {}", p, value.len());
-                    // 对于 -p，打印其中的每个路径用于调试
-                    if p == "-p" || p == "--module-path" {
-                        for piece in value.split(|c| c == ';' || c == ':') {
-                            if !piece.trim().is_empty() {
-                                let path_buf = PathBuf::from(piece.trim());
-                                let exists = path_buf.exists();
-                                debug!("  module-path 项: {} (存在: {})", piece.trim(), exists);
+                args.push(p.clone());
+                if has_value {
+                    // 对于 -p/--module-path，额外检查其中引用的 JAR 是否存在
+                    let value = &jvm_args_from_version[i + 1];
+                    if is_module_or_class_path_key {
+                        debug!("[HMCL 模式] 使用 Forge 参数: {} 值长度: {}", p, value.len());
+                        // 对 -cp/-p 的值做去重，避免 PCL 等生成的 json 里重复的
+                        // jar 路径导致 UnionFileSystem "Duplicate key" 崩溃
+                        args.push(dedup_path_list(value));
+                        // 对于 -p，打印其中的每个路径用于调试
+                        if p == "-p" || p == "--module-path" {
+                            for piece in value.split(|c| c == ';' || c == ':') {
+                                if !piece.trim().is_empty() {
+                                    let path_buf = PathBuf::from(piece.trim());
+                                    let exists = path_buf.exists();
+                                    debug!("  module-path 项: {} (存在: {})", piece.trim(), exists);
+                                }
                             }
                         }
+                    } else {
+                        args.push(value.clone());
                     }
+                    i += 2;
+                } else {
+                    i += 1;
                 }
-                args.push(value.clone());
-                i += 2;
-            } else {
-                i += 1;
-            }
         }
     }
 

--- a/src-tauri/src/handler/launcher/arguments.rs
+++ b/src-tauri/src/handler/launcher/arguments.rs
@@ -1946,14 +1946,18 @@ pub(super) fn build_jvm_arguments_inner(
     // 只在neoforge时使用loadName，其他modloader使用version_name
     // 仅靠 loadName 是否包含 "neoforge" 判断不够可靠：
     // 合并型整合包（如 "PVZ_Survive"）的目录名不含 neoforge 却仍是 NeoForge，
+    // PCL 安装的 NeoForge 实例（如 "_ _ _ _ - _ _ _"）mainClass 与 Forge 相同，
+    // 且没有 net.neoforged:neoforge 坐标，只带 fancymodloader 库。
     // 需要再从已解析的 version.json 主类/库坐标交叉确认。
     let is_neoforge = loadType != "0"
         && (!loadName.is_empty() && loadName.to_lowercase().contains("neoforge")
             || version_json.main_class.to_lowercase().contains("neoforged")
-            || version_json
-                .libraries
-                .iter()
-                .any(|lib| lib.name.to_lowercase().contains("net.neoforged:neoforge:")));
+            || version_json.libraries.iter().any(|lib| {
+                let n = lib.name.to_lowercase();
+                n.contains("net.neoforged:fancymodloader:")
+                    || n.contains("net.neoforged:neoforge:")
+                    || n.contains("net.neoforged:fmlloader:")
+            }));
     // 对于loadType为1的情况，如果是neoforge，使用loadName；否则使用version_name
     let native_version = if loadType == "1" && is_neoforge {
         &loadName

--- a/src-tauri/src/handler/launcher/arguments.rs
+++ b/src-tauri/src/handler/launcher/arguments.rs
@@ -118,7 +118,18 @@ pub(super) fn append_loader_jvm_args(args: &mut Vec<String>, loader_args: &[Stri
             key.as_str(),
             "-p" | "--module-path" | "-cp" | "--class-path"
         );
-        let already_present = is_path_key && args.iter().any(|arg| arg == key);
+        // 已存在的参数键直接跳过，避免同一参数被拼接多次
+        // （如 -Xss1M、-XX:HeapDumpPath、-Djava.library.path 在固定参数、
+        // version json jvm 参数、loader 参数三处都可能出现）。
+        // -D 风格参数按 `-Dxxx` 前缀比较：两处占位符替换结果可能不同
+        // （version json 处理时被替换成 -Dxxx={}，loader 里是真实值），
+        // 完整字符串比较会漏掉重复，导致垃圾值混入启动参数。
+        let already_present = args.iter().any(|arg| {
+            arg == key
+                || (arg.starts_with("-D")
+                    && key.starts_with("-D")
+                    && arg.split('=').next() == key.split('=').next())
+        });
 
         if !already_present {
             args.push(key.clone());
@@ -134,6 +145,145 @@ pub(super) fn append_loader_jvm_args(args: &mut Vec<String>, loader_args: &[Stri
         }
 
         index += if has_value { 2 } else { 1 };
+    }
+}
+
+/// 合并 version json 的 jvm 参数（jvm_args_from_version）到总参数列表。
+///
+/// 去重按参数“键”比较（-Dxxx=value 只取 -Dxxx 部分），而不是比较完整字符串：
+/// 同一个参数在两处占位符替换结果可能不同（例如 jvm 参数里的
+/// -Djava.library.path 在 version json 处理时被替换成 -Djava.library.path={}，
+/// 而 loader 里是完整的原生路径），完整字符串比较会漏掉重复，
+/// 导致 -Djava.library.path={} 这类垃圾值混入启动参数。
+/// -p/--module-path、-cp/--class-path 是加载器精心设计的关键参数，
+/// 始终优先使用 jvm_args_from_version 中的（load json 的 -cp 值可能为 {} 垃圾）。
+pub(super) fn merge_version_jvm_args(
+    args: &mut Vec<String>,
+    jvm_args_from_version: &[String],
+    extra_before_cp: &[String],
+) {
+    let key_of = |p: &str| -> String {
+        if p.starts_with('-') {
+            p.split('=').next().unwrap_or(p).to_string()
+        } else {
+            p.to_string()
+        }
+    };
+
+    // 先收集已在 extra_before_cp 中的参数键，避免重复
+    let mut existing_keys: HashSet<String> = HashSet::new();
+    {
+        let mut ei = 0;
+        while ei < extra_before_cp.len() {
+            let p = &extra_before_cp[ei];
+            let has_value = p.starts_with('-')
+                && ei + 1 < extra_before_cp.len()
+                && !extra_before_cp[ei + 1].starts_with('-');
+            if p.starts_with('-') {
+                // 记录 key（如 -p, -cp, --module-path 等）
+                existing_keys.insert(key_of(p));
+            }
+            if has_value {
+                ei += 2;
+            } else {
+                ei += 1;
+            }
+        }
+    }
+
+    // 然后添加 jvm_args_from_version 中的参数（跳过已在 extra_before_cp 中的 key）
+    let mut i = 0;
+    while i < jvm_args_from_version.len() {
+        let p = &jvm_args_from_version[i];
+        let has_value = p.starts_with('-')
+            && i + 1 < jvm_args_from_version.len()
+            && !jvm_args_from_version[i + 1].starts_with('-');
+
+        // 去重：如果 key 已存在于 extra_before_cp 中，跳过
+        // 但 -p/--module-path、-cp/--class-path 是关键参数，始终优先使用 jvm_args_from_version 中的
+        let is_module_or_class_path_key =
+            p == "-p" || p == "--module-path" || p == "-cp" || p == "--class-path";
+        if !is_module_or_class_path_key && existing_keys.contains(&key_of(p)) {
+            i += if has_value { 2 } else { 1 };
+            continue;
+        }
+
+        // 占位符替换失败的垃圾值（-Dxxx={}）永远不会是合法参数，
+        // 即使 loader 里没有同名键也不允许混入启动命令
+        let is_placeholder_garbage = p.starts_with("-D") && p.ends_with("={}");
+        if is_placeholder_garbage {
+            i += if has_value { 2 } else { 1 };
+            continue;
+        }
+
+        args.push(p.clone());
+        if has_value {
+            // 对于 -p/--module-path，额外检查其中引用的 JAR 是否存在
+            let value = &jvm_args_from_version[i + 1];
+            if is_module_or_class_path_key {
+                debug!("[HMCL 模式] 使用 Forge 参数: {} 值长度: {}", p, value.len());
+                // 对 -cp/-p 的值做去重，避免 PCL 等生成的 json 里重复的
+                // jar 路径导致 UnionFileSystem "Duplicate key" 崩溃
+                args.push(dedup_path_list(value));
+                // 对于 -p，打印其中的每个路径用于调试
+                if p == "-p" || p == "--module-path" {
+                    for piece in value.split(|c| c == ';' || c == ':') {
+                        if !piece.trim().is_empty() {
+                            let path_buf = PathBuf::from(piece.trim());
+                            let exists = path_buf.exists();
+                            debug!("  module-path 项: {} (存在: {})", piece.trim(), exists);
+                        }
+                    }
+                }
+            } else {
+                args.push(value.clone());
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// 合并 load json 的 game 参数（extra_after_cp）到游戏参数列表。
+///
+/// 只补充缺失的 --key 参数及其值：已存在的 --key 参数整对跳过（包括它的值），
+/// 否则裸值会被再次追加到参数列表末尾（如 --fml.neoForgeVersion 21.1.238 的裸值
+/// 21.1.238 会被重复拼到命令尾部），造成启动参数大量重复拼接。
+pub(super) fn merge_loader_game_args(game_args: &mut Vec<String>, extra_after_cp: &[String]) {
+    let mut li = 0;
+    while li < extra_after_cp.len() {
+        let tok = &extra_after_cp[li];
+
+        // 检查是否是占位符参数（如 ${auth_player_name}）
+        let is_placeholder = tok.starts_with("${") && tok.ends_with("}");
+        if is_placeholder {
+            li += 1;
+            continue;
+        }
+
+        if tok.starts_with("--") {
+            // --key 参数：已存在则整对跳过；缺失则连值一起补入
+            let has_value =
+                li + 1 < extra_after_cp.len() && !extra_after_cp[li + 1].starts_with("--");
+            if !game_args.contains(tok) {
+                game_args.push(tok.clone());
+                if has_value {
+                    game_args.push(extra_after_cp[li + 1].clone());
+                }
+            }
+            li += if has_value { 2 } else { 1 };
+        } else {
+            // 裸值：若它紧跟的 --key 已存在于参数列表，说明它属于那个
+            // 已存在的参数，跳过避免末尾重复；否则保留原行为
+            let value_of_existing_key = li > 0
+                && extra_after_cp[li - 1].starts_with("--")
+                && game_args.contains(&extra_after_cp[li - 1]);
+            if !value_of_existing_key {
+                game_args.push(tok.clone());
+            }
+            li += 1;
+        }
     }
 }
 
@@ -1745,10 +1895,17 @@ pub(super) fn build_jvm_arguments_inner(
             }
 
             // 占位符替换函数（参照 HMCL）
+            let jvm_natives_dir = format_path(
+                minecraft_path_buf
+                    .join("versions")
+                    .join(&version_name)
+                    .join(format!("{}-natives", &version_name)),
+            );
             let replace_placeholders = |s: &str| -> String {
                 let mut result = s.to_string();
                 result = result.replace("${classpath_separator}", classpath_sep);
                 result = result.replace("${library_directory}", &library_dir);
+                result = result.replace("${natives_directory}", &jvm_natives_dir);
                 result = result.replace("${version_name}", &version_name);
                 result = result.replace("${launcher_name}", "RTLauncher");
                 result = result.replace("${launcher_version}", env!("CARGO_PKG_VERSION"));
@@ -1954,7 +2111,9 @@ pub(super) fn build_jvm_arguments_inner(
             || version_json.main_class.to_lowercase().contains("neoforged")
             || version_json.libraries.iter().any(|lib| {
                 let n = lib.name.to_lowercase();
-                n.contains("net.neoforged:fancymodloader:")
+                // 注意: NeoForge 加载器坐标是 net.neoforged.fancymodloader:loader:4.0.43
+                // （neoforged 后是点而不是冒号），漏掉它会误判为 Forge
+                n.contains("net.neoforged.fancymodloader:")
                     || n.contains("net.neoforged:neoforge:")
                     || n.contains("net.neoforged:fmlloader:")
             }));
@@ -2058,77 +2217,7 @@ pub(super) fn build_jvm_arguments_inner(
     // Forge 自己指定的 -p (--module-path) 和 -cp 参数必须被正确加入
     // 处理 -p 和 -cp 等带空格分隔值的参数
     // 同时去重：避免 extra_before_cp 和 jvm_args_from_version 的参数重复（尤其 `-p`/`-cp`）
-    {
-        // 先收集已在 extra_before_cp 中的参数键，避免重复
-        let mut existing_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
-        {
-            let mut ei = 0;
-            while ei < extra_before_cp.len() {
-                let p = &extra_before_cp[ei];
-                let has_value = p.starts_with('-')
-                    && ei + 1 < extra_before_cp.len()
-                    && !extra_before_cp[ei + 1].starts_with('-');
-                if p.starts_with('-') {
-                    // 记录 key（如 -p, -cp, --module-path 等）
-                    existing_keys.insert(p.clone());
-                }
-                if has_value {
-                    ei += 2;
-                } else {
-                    ei += 1;
-                }
-            }
-        }
-
-        // 然后添加 jvm_args_from_version 中的参数（跳过已在 extra_before_cp 中的 key）
-        let mut i = 0;
-        while i < jvm_args_from_version.len() {
-            let p = &jvm_args_from_version[i];
-            let has_value = p.starts_with('-')
-                && i + 1 < jvm_args_from_version.len()
-                && !jvm_args_from_version[i + 1].starts_with('-');
-
-            // 去重：如果 key 已存在于 extra_before_cp 中，跳过
-            // 但 -p/--module-path、-cp/--class-path 是关键参数，始终优先使用 jvm_args_from_version 中的
-            let is_module_or_class_path_key =
-                p == "-p" || p == "--module-path" || p == "-cp" || p == "--class-path";
-            if !is_module_or_class_path_key && existing_keys.contains(p) {
-                if has_value {
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-                continue;
-            }
-
-                args.push(p.clone());
-                if has_value {
-                    // 对于 -p/--module-path，额外检查其中引用的 JAR 是否存在
-                    let value = &jvm_args_from_version[i + 1];
-                    if is_module_or_class_path_key {
-                        debug!("[HMCL 模式] 使用 Forge 参数: {} 值长度: {}", p, value.len());
-                        // 对 -cp/-p 的值做去重，避免 PCL 等生成的 json 里重复的
-                        // jar 路径导致 UnionFileSystem "Duplicate key" 崩溃
-                        args.push(dedup_path_list(value));
-                        // 对于 -p，打印其中的每个路径用于调试
-                        if p == "-p" || p == "--module-path" {
-                            for piece in value.split(|c| c == ';' || c == ':') {
-                                if !piece.trim().is_empty() {
-                                    let path_buf = PathBuf::from(piece.trim());
-                                    let exists = path_buf.exists();
-                                    debug!("  module-path 项: {} (存在: {})", piece.trim(), exists);
-                                }
-                            }
-                        }
-                    } else {
-                        args.push(value.clone());
-                    }
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-        }
-    }
+    merge_version_jvm_args(&mut args, &jvm_args_from_version, &extra_before_cp);
 
     // 再处理独立加载器 JSON 的参数。version_name 可能指向原版 JSON，而
     // loadName 指向 Forge JSON；这种情况下 Forge 的 -p 只在这里出现。
@@ -2242,26 +2331,11 @@ pub(super) fn build_jvm_arguments_inner(
         .to_string(),
     ]);
 
-    // 修复点2: 不进行去重检查，确保load中game里面的所有参数都被加入总启动参数中
-    {
-        let mut li = 0;
-        while li < extra_after_cp.len() {
-            let tok = &extra_after_cp[li];
-
-            // 检查是否是占位符参数（如 ${auth_player_name}）
-            let is_placeholder = tok.starts_with("${") && tok.ends_with("}");
-
-            // 只过滤占位符参数，其他参数都保留
-            if is_placeholder {
-                li += 1;
-                continue;
-            }
-            if !(game_args_vec.contains(tok) && tok.starts_with("--")) {
-                game_args_vec.push(tok.clone());
-            }
-            li += 1;
-        }
-    }
+    // 修复点2: 合并 load 中的 game 参数，只补充缺失的 --key 参数及其值。
+    // 已存在的 --key 参数整对跳过（包括它的值），否则裸值会被再次追加到
+    // 参数列表末尾（如 --fml.neoForgeVersion 21.1.238 的裸值 21.1.238 会被
+    // 重复拼到命令尾部），造成启动参数大量重复拼接。
+    merge_loader_game_args(&mut game_args_vec, &extra_after_cp);
 
     // 修复点3: 改进参数转发逻辑
     let mut forwarded_args: Vec<String> = Vec::new();

--- a/src-tauri/src/handler/launcher/arguments.rs
+++ b/src-tauri/src/handler/launcher/arguments.rs
@@ -118,13 +118,21 @@ pub(super) fn append_loader_jvm_args(args: &mut Vec<String>, loader_args: &[Stri
             key.as_str(),
             "-p" | "--module-path" | "-cp" | "--class-path"
         );
+        // --add-opens/--add-exports/--add-reads 可多次出现且每次开放的目标
+        // 模块不同（ALL-UNNAMED vs 具名模块），不能按键去重，否则 loader
+        // 的具名模块参数会被固定参数吞掉（如 java.base/java.lang.invoke 开放
+        // 给 cpw.mods.securejarhandler 就依赖这条不被吞掉）
+        let is_multi_flag = matches!(
+            key.as_str(),
+            "--add-opens" | "--add-exports" | "--add-reads"
+        );
         // 已存在的参数键直接跳过，避免同一参数被拼接多次
         // （如 -Xss1M、-XX:HeapDumpPath、-Djava.library.path 在固定参数、
         // version json jvm 参数、loader 参数三处都可能出现）。
         // -D 风格参数按 `-Dxxx` 前缀比较：两处占位符替换结果可能不同
         // （version json 处理时被替换成 -Dxxx={}，loader 里是真实值），
         // 完整字符串比较会漏掉重复，导致垃圾值混入启动参数。
-        let already_present = args.iter().any(|arg| {
+        let already_present = !is_multi_flag && args.iter().any(|arg| {
             arg == key
                 || (arg.starts_with("-D")
                     && key.starts_with("-D")
@@ -2047,6 +2055,27 @@ pub(super) fn build_jvm_arguments_inner(
             // 不添加针对具名模块的 --add-opens 和 --add-reads
             // 因为这些模块在 Java 启动时还不存在，Forge 会自己创建 ModuleLayer
         ]);
+
+        if uses_module_system {
+            // securejarhandler（Forge/NeoForge 1.17+ 的 jar 处理模块）在类初始化
+            // 时会对 MethodHandles.Lookup.IMPL_LOOKUP 调用 setAccessible，
+            // java.base 必须把 java.lang.invoke 开放给 cpw.mods.securejarhandler
+            // 这个具名模块，否则 UnionFileSystem 类初始化直接崩溃
+            // （ExceptionInInitializerError: Unable to make field ... IMPL_LOOKUP
+            // accessible）。
+            // NeoForge 21.1.x 的 json 只自带 java.util.jar 与 sun.security.util
+            // 两条开放；java.lang.invoke 这条 PCL 等启动器由自身固定参数补齐，
+            // 实例 json 里没有，这里统一兜底（本地自装实例能启动是因为安装器
+            // 把三条都写进了 json，PCL 安装的实例只带两条）。
+            args.extend(vec![
+                "--add-opens".to_string(),
+                "java.base/java.lang.invoke=cpw.mods.securejarhandler".to_string(),
+                "--add-opens".to_string(),
+                "java.base/java.util.jar=cpw.mods.securejarhandler".to_string(),
+                "--add-exports".to_string(),
+                "java.base/sun.security.util=cpw.mods.securejarhandler".to_string(),
+            ]);
+        }
     }
 
     if let Some(logging) = &version_json.logging {

--- a/src-tauri/src/version_management/mod.rs
+++ b/src-tauri/src/version_management/mod.rs
@@ -102,6 +102,49 @@ fn detect_loader_from_main_class(main_class: &str) -> &'static str {
     }
 }
 
+/// 从加载器库坐标推断加载器类型（比 mainClass 更可靠）。
+///
+/// NeoForge 与 Forge 的 mainClass 同为 `cpw.mods.bootstraplauncher.BootstrapLauncher`，
+/// 无法区分；而库坐标是各自独占的：
+/// - NeoForge: `net.neoforged:fancymodloader:*` / `net.neoforged:neoforge:*` / `net.neoforged:fmlloader:*`
+/// - Forge: `net.minecraftforge:forge:*` / `net.minecraftforge:fmlloader:*`
+///
+/// 注意 `net.minecraftforge:srgutils` 是两者共用库，不能作为 Forge 的判据。
+fn detect_loader_from_libraries(json: &serde_json::Value) -> Option<&'static str> {
+    let libraries = json.get("libraries")?.as_array()?;
+    let mut has_forge_fml = false;
+    for library in libraries {
+        let name = library.get("name")?.as_str()?.to_lowercase();
+        if name.starts_with("net.neoforged:fancymodloader:")
+            || name.starts_with("net.neoforged:neoforge:")
+            || name.starts_with("net.neoforged:fmlloader:")
+        {
+            return Some("NeoForge");
+        }
+        if name.starts_with("net.minecraftforge:forge:")
+            || name.starts_with("net.minecraftforge:fmlloader:")
+        {
+            has_forge_fml = true;
+        }
+        if name.starts_with("net.fabricmc:loader:")
+            || name.starts_with("net.fabricmc:fabric-loader:")
+        {
+            return Some("Fabric");
+        }
+        if name.starts_with("org.quiltmc:quilt-loader:") {
+            return Some("Quilt");
+        }
+        if name.starts_with("com.mumfrey:liteloader:") {
+            return Some("LiteLoader");
+        }
+    }
+    if has_forge_fml {
+        Some("Forge")
+    } else {
+        None
+    }
+}
+
 /// 从版本文件夹名中快速推断加载器（备用方案）
 fn detect_loader_from_name(name: &str) -> &'static str {
     let lower = name.to_lowercase();
@@ -351,20 +394,27 @@ fn build_instance_data(instance_dir: &Path, minecraft_path: &Path) -> Option<Ins
                                 mc_ver = alt;
                             }
                         }
-                        // 从 mainClass 推断加载器，但与文件夹名交叉验证
-                        // （NeoForge 的 mainClass 可能与 Forge 相同，需要用文件夹名区分）
+                        // 从 mainClass 推断加载器，但用库坐标与文件夹名交叉验证
+                        // （NeoForge 与 Forge 的 mainClass 相同，PCL 等第三方启动器安装的
+                        // NeoForge 实例文件夹名也不含 neoforge，必须靠库坐标区分）
                         let from_main = json
                             .get("mainClass")
                             .and_then(|v| v.as_str())
                             .map(detect_loader_from_main_class)
                             .unwrap_or("Vanilla");
                         let from_name = detect_loader_from_name(&name);
-                        let loader = if from_main == "Forge" && from_name == "NeoForge" {
-                            // mainClass 误判为 Forge，但文件夹名明确是 NeoForge → 以文件夹名为准
-                            "NeoForge"
-                        } else if from_main == "Forge" && from_name == "OptiFine" {
-                            // OptiFine 继承 Forge 的 mainClass，但文件夹名明确是 OptiFine → 以文件夹名为准
+                        let from_libs = detect_loader_from_libraries(&json);
+                        let loader = if from_name == "OptiFine"
+                            && (from_main == "Forge" || from_libs == Some("Forge"))
+                        {
+                            // OptiFine 继承 Forge 的 mainClass 和库，但文件夹名明确是 OptiFine
                             "OptiFine"
+                        } else if let Some(l) = from_libs {
+                            // 库坐标是最可靠的判据（NeoForge 1.20.2+ 独占 net.neoforged 坐标）
+                            l
+                        } else if from_main == "Forge" && from_name == "NeoForge" {
+                            // 合并型整合包无 net.neoforged 库坐标时，用文件夹名兜底区分
+                            "NeoForge"
                         } else if from_main == "Vanilla" {
                             // mainClass 无法判断 → 用文件夹名
                             from_name
@@ -701,7 +751,7 @@ pub async fn vm_delete_cached_file(
 #[cfg(test)]
 mod tests {
     use super::{
-        detect_loader_from_main_class, detect_loader_from_name,
+        detect_loader_from_libraries, detect_loader_from_main_class, detect_loader_from_name,
         detect_minecraft_version_from_libraries, detect_minecraft_version_from_patches,
         extract_minecraft_version, version_from_instance_name,
     };
@@ -851,6 +901,98 @@ mod tests {
             detect_loader_from_name("1.21.1-OptiFine-HD_U_I7"),
             "OptiFine"
         );
+    }
+
+    #[test]
+    fn detects_pcl_style_neoforge_from_fancymodloader_libraries() {
+        // PCL 安装的 NeoForge 1.21.1 实例：mainClass 与 Forge 相同，
+        // 没有 net.neoforged:neoforge 坐标，只有 fancymodloader 库。
+        let version = json!({
+            "mainClass": "cpw.mods.bootstraplauncher.BootstrapLauncher",
+            "libraries": [
+                { "name": "net.neoforged:fancymodloader:loader:4.0.43" },
+                { "name": "net.neoforged:fancymodloader:earlydisplay:4.0.43" },
+                { "name": "net.minecraftforge:srgutils:0.4.15" }
+            ]
+        });
+        assert_eq!(
+            detect_loader_from_libraries(&version),
+            Some("NeoForge")
+        );
+    }
+
+    #[test]
+    fn detects_older_neoforge_from_neoforge_artifact() {
+        // NeoForge 1.20.2-1.20.4 的用户加载器坐标是 net.neoforged:neoforge
+        let version = json!({
+            "libraries": [
+                { "name": "net.neoforged:neoforge:1.20.4-21.0.14" }
+            ]
+        });
+        assert_eq!(
+            detect_loader_from_libraries(&version),
+            Some("NeoForge")
+        );
+    }
+
+    #[test]
+    fn detects_forge_from_net_minecraftforge_coordinates() {
+        let version = json!({
+            "libraries": [
+                { "name": "net.minecraftforge:forge:1.20.1-47.4.9" },
+                { "name": "net.minecraftforge:fmlloader:1.20.1-47.4.9" }
+            ]
+        });
+        assert_eq!(
+            detect_loader_from_libraries(&version),
+            Some("Forge")
+        );
+    }
+
+    #[test]
+    fn srgutils_alone_is_not_forge() {
+        // srgutils 是 Forge/NeoForge 共用库，单独出现不能当作 Forge 判据
+        let version = json!({
+            "libraries": [
+                { "name": "net.minecraftforge:srgutils:0.4.15" },
+                { "name": "cpw.mods:modlauncher:11.0.5" }
+            ]
+        });
+        assert_eq!(detect_loader_from_libraries(&version), None);
+    }
+
+    #[test]
+    fn detects_fabric_and_quilt_from_loader_coordinates() {
+        let fabric = json!({
+            "libraries": [
+                { "name": "net.fabricmc:loader:0.15.11" },
+                { "name": "net.fabricmc:intermediary:1.21.1" }
+            ]
+        });
+        assert_eq!(
+            detect_loader_from_libraries(&fabric),
+            Some("Fabric")
+        );
+        let quilt = json!({
+            "libraries": [
+                { "name": "org.quiltmc:quilt-loader:0.25.0" }
+            ]
+        });
+        assert_eq!(
+            detect_loader_from_libraries(&quilt),
+            Some("Quilt")
+        );
+    }
+
+    #[test]
+    fn no_loader_libraries_means_unknown() {
+        let version = json!({
+            "libraries": [
+                { "name": "com.mojang:minecraft:1.21.1" },
+                { "name": "org.lwjgl:lwjgl:3.3.3" }
+            ]
+        });
+        assert_eq!(detect_loader_from_libraries(&version), None);
     }
 
     #[test]


### PR DESCRIPTION
- 数据库改存各平台隐藏的用户数据目录(Linux ~/.local/share, macOS Application Support, Windows %APPDATA%), 不再暴露于可执行文件目录

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stores application data in a hidden per-user directory by default.
  * Automatically detects PCL2 game directories, including portable installations.
  * Improves recognition of Forge, NeoForge, Fabric, Quilt, and LiteLoader installations.
  * Includes console logs in exported launch reports when available.

* **Bug Fixes**
  * Locates existing data in legacy locations and downloads missing data with fallback support.
  * Creates required directories before downloads and reports clearer errors with timeout protection.
  * Improves compatibility with non-UTF-8 launcher configuration files.
  * Removes duplicate JVM, classpath, game arguments, and launcher paths.
  * Improves handling of unresolved JVM placeholders and launcher-specific arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->