### PR TITLE
Contents online pull

### DIFF
--- a/components/home/announcement-card.tsx
+++ b/components/home/announcement-card.tsx
@@ -10,8 +10,10 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ANNOUNCEMENTS } from "@/constants/data";
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Announcement } from "@/types";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useState } from "react";
 import { slideLeftContent } from "@/lib/motion";
 import { useI18n } from "@/components/i18n/use-i18n";
 
@@ -22,14 +24,30 @@ const ANNOUNCEMENT_COPY = [
 ] as const;
 
 export function AnnouncementCard({ compact = false }: { compact?: boolean }) {
-  const { t } = useI18n();
+  const { t, language } = useI18n();
   const [current, setCurrent] = useState(0);
-  const announcement = ANNOUNCEMENT_COPY[current] ?? ANNOUNCEMENT_COPY[0];
+  const [remote, setRemote] = useState<Announcement[] | null>(null);
+  const announcement = (remote && remote.length > 0 ? remote : ANNOUNCEMENT_COPY)[current] ?? ANNOUNCEMENT_COPY[0];
 
+  useEffect(() => {
+    // 拉取本地 announcements 文件（由后端定期 sync 到仓库）
+    const langCode = language === "zh-CN" ? "zh_cn" : "en_us";
+    void invoke<Announcement[]>("get_announcements", { language: langCode })
+      .then((list) => {
+        if (list && list.length > 0) setRemote(list);
+      })
+      .catch(() => {});
+  }, [language]);
+
+  const total = (remote && remote.length > 0) ? remote.length : ANNOUNCEMENT_COPY.length;
   const prev = () =>
-    setCurrent((i) => (i - 1 + ANNOUNCEMENTS.length) % ANNOUNCEMENTS.length);
+    setCurrent((i) => (i - 1 + total) % total);
   const next = () =>
-    setCurrent((i) => (i + 1) % ANNOUNCEMENTS.length);
+    setCurrent((i) => (i + 1) % total);
+
+  // 当远程公告存在时直接显示其文本；否则对内置副本使用 i18n 翻译键
+  const displayedTitle = remote && remote.length > 0 ? announcement.title : t((announcement as any).title);
+  const displayedContent = remote && remote.length > 0 ? announcement.content : t((announcement as any).content);
 
   if (compact) {
     return (
@@ -48,9 +66,9 @@ export function AnnouncementCard({ compact = false }: { compact?: boolean }) {
                 animate="animate"
                 exit="exit"
               >
-                <h3 className="font-medium text-xs">{t(announcement.title)}</h3>
+                <h3 className="font-medium text-xs">{displayedTitle}</h3>
                 <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-                  {t(announcement.content)}
+                  {displayedContent}
                 </p>
               </motion.div>
             </AnimatePresence>
@@ -60,7 +78,7 @@ export function AnnouncementCard({ compact = false }: { compact?: boolean }) {
               <ChevronLeft className="size-3" />
             </Button>
             <span className="text-xs text-muted-foreground">
-              {current + 1} / {ANNOUNCEMENTS.length}
+              {current + 1} / {total}
             </span>
             <Button variant="outline" size="icon-sm" onClick={next}>
               <ChevronRight className="size-3" />
@@ -87,9 +105,9 @@ export function AnnouncementCard({ compact = false }: { compact?: boolean }) {
               animate="animate"
               exit="exit"
             >
-              <h3 className="font-medium text-sm">{t(announcement.title)}</h3>
+              <h3 className="font-medium text-sm">{displayedTitle}</h3>
               <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-                {t(announcement.content)}
+                {displayedContent}
               </p>
             </motion.div>
           </AnimatePresence>
@@ -99,7 +117,7 @@ export function AnnouncementCard({ compact = false }: { compact?: boolean }) {
             <ChevronLeft className="size-4" />
           </Button>
           <span className="text-xs text-muted-foreground">
-            {current + 1} / {ANNOUNCEMENTS.length}
+            {current + 1} / {total}
           </span>
           <Button variant="outline" size="icon-sm" onClick={next}>
             <ChevronRight className="size-4" />

--- a/hooks/use-instances.ts
+++ b/hooks/use-instances.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import type { InstanceData } from "@/types";
 
 interface UseInstancesReturn {
@@ -85,6 +86,40 @@ export function useInstances(instancesPath?: string): UseInstancesReturn {
       requestIdRef.current += 1;
     };
   }, [fetch]);
+
+  // 当安装/下载完成（例如 Forge / NeoForge）时，自动触发一次刷新。
+  useEffect(() => {
+    if (!instancesPath) return;
+    const handlers: Promise<UnlistenFn>[] = [];
+
+    const tryListen = (eventName: string) =>
+      listen<{ task_id: number; success: boolean }>(eventName, (e) => {
+        const payload = e.payload as { task_id: number; success: boolean } | undefined;
+        if (payload && payload.success) {
+          void fetch();
+        }
+      });
+
+    handlers.push(tryListen("forge-download-finished"));
+    handlers.push(tryListen("neoforge-download-finished"));
+
+    let unlistens: UnlistenFn[] = [];
+    Promise.all(handlers)
+      .then((fns) => {
+        unlistens = fns;
+      })
+      .catch(() => {
+        /* ignore */
+      });
+
+    return () => {
+      for (const u of unlistens) {
+        try {
+          u();
+        } catch (_) {}
+      }
+    };
+  }, [instancesPath, fetch]);
 
   return {
     instances,

--- a/src-tauri/src/handler/announcements.rs
+++ b/src-tauri/src/handler/announcements.rs
@@ -1,0 +1,95 @@
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+
+/// 同步 GitHub 仓库中指定目录下的公告文本文件到本地 `announcements/` 目录。
+/// 参数均为字符串，branch 可为空表示使用 "main"。
+#[tauri::command]
+pub fn sync_announcements(owner: String, repo: String, path: String, branch: Option<String>) -> Result<usize, String> {
+    let branch = branch.unwrap_or_else(|| "main".to_string());
+    let api_url = format!(
+        "https://api.github.com/repos/cqw-acq/RTLauncher_new/contents/?ref={branch}"
+    );
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .get(&api_url)
+        .header("User-Agent", "RTLauncher/announcements-sync")
+        .send()
+        .map_err(|e| format!("请求 GitHub API 失败: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("GitHub API 返回错误状态: {}", resp.status()));
+    }
+
+    let items: serde_json::Value = resp.json().map_err(|e| format!("解析 GitHub 响应失败: {}", e))?;
+    if !items.is_array() {
+        return Err("GitHub 返回的内容目录格式不正确".to_string());
+    }
+
+    let mut saved = 0usize;
+    let cwd = std::env::current_dir().map_err(|e| format!("无法获取当前目录: {}", e))?;
+    let announcements_dir = cwd.join("announcements");
+    if !announcements_dir.exists() {
+        fs::create_dir_all(&announcements_dir).map_err(|e| format!("创建目录失败: {}", e))?;
+    }
+
+    for item in items.as_array().unwrap() {
+        if item.get("type").and_then(|v| v.as_str()) != Some("file") {
+            continue;
+        }
+        let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        if !name.to_lowercase().ends_with(".txt") {
+            continue;
+        }
+        let download_url = item.get("download_url").and_then(|v| v.as_str()).ok_or_else(|| "缺少 download_url".to_string())?;
+        let file_resp = client
+            .get(download_url)
+            .header("User-Agent", "RTLauncher/announcements-sync")
+            .send()
+            .map_err(|e| format!("下载公告文件失败: {}", e))?;
+        if !file_resp.status().is_success() {
+            continue;
+        }
+        let content = file_resp.text().map_err(|e| format!("读取公告文件内容失败: {}", e))?;
+        let target = announcements_dir.join(name);
+        fs::write(&target, content).map_err(|e| format!("写入公告文件失败: {}", e))?;
+        saved += 1;
+    }
+
+    Ok(saved)
+}
+
+#[derive(Serialize)]
+pub struct Announcement {
+    pub id: String,
+    pub title: String,
+    pub content: String,
+}
+
+/// 从本地 `announcements/` 目录读取所有 txt 文件并返回解析后的公告。
+#[tauri::command]
+pub fn get_announcements() -> Result<Vec<Announcement>, String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("无法获取当前目录: {}", e))?;
+    let announcements_dir = cwd.join("announcements");
+    if !announcements_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut result: Vec<Announcement> = Vec::new();
+    for entry in fs::read_dir(&announcements_dir).map_err(|e| format!("读取目录失败: {}", e))? {
+        let entry = entry.map_err(|e| format!("读取目录项失败: {}", e))?;
+        let path: PathBuf = entry.path();
+        if !path.is_file() { continue; }
+        if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+            if ext.to_lowercase() != "txt" { continue; }
+        } else { continue; }
+
+        let content = fs::read_to_string(&path).map_err(|e| format!("读取文件失败: {}", e))?;
+        let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown").to_string();
+        let mut lines = content.lines();
+        let title = lines.next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).unwrap_or_else(|| id.clone());
+        let body = lines.collect::<Vec<&str>>().join("\n");
+        result.push(Announcement { id, title, content: body });
+    }
+    Ok(result)
+}

--- a/src-tauri/src/handler/mod.rs
+++ b/src-tauri/src/handler/mod.rs
@@ -19,6 +19,7 @@ pub mod mod_links;
 pub mod mod_parser;
 #[allow(dead_code)]
 pub mod modpack_builder;
+pub mod announcements;
 #[allow(non_snake_case)]
 pub mod modpack_installer_handler;
 #[allow(dead_code, non_snake_case)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,10 +8,11 @@ mod auth;
 mod downloader;
 mod handler;
 mod http_client;
-mod multiplayer;
+mod mutiplayer;
 mod themes;
 mod updater;
 mod version_management;
+use handler::announcements::{sync_announcements, get_announcements};
 use auth::littleskinLoader::{useMethod, use_method_with_credentials};
 use auth::official::{
     delete_cached_skin, get_skin_base64, ms_activate_skin, ms_cancel_login, ms_delete_skin,
@@ -82,13 +83,11 @@ use handler::diagnostics::{
     export_launch_report, check_mod_installed,
 };
 use handler::mod_links::{get_modrinth_required_dependencies, get_curseforge_required_dependencies};
-use multiplayer::{
+use mutiplayer::{
     ensure_openp2p_stopped, mp_check_openp2p, mp_encode_room_info, mp_get_openp2p_dir,
     mp_get_openp2p_path, mp_install_openp2p, mp_is_openp2p_running, mp_poll_log,
-    mp_start_openp2p_host, mp_start_openp2p_join, mp_stop_openp2p,
+    mp_start_openp2p_host, mp_start_openp2p_join, mp_stop_openp2p, quick_kill_openp2p,
 };
-#[cfg(target_os = "windows")]
-use multiplayer::quick_kill_openp2p;
 use updater::handler::{
     cancel_update, can_check_update, check_for_updates, create_updater_state, download_update,
     get_target_version, get_update_status, install_update,
@@ -167,6 +166,8 @@ pub fn run() {
             mp_get_openp2p_dir,
             mp_get_openp2p_path,
             vm_scan_instances,
+            sync_announcements,
+            get_announcements,
             vm_find_resource_packs,
             vm_parse_level_dat,
             vm_modify_game_rule,
@@ -325,6 +326,23 @@ pub fn run() {
 
                 win_builder.build()?
             };
+
+            // 在后台异步同步公告到本地（非阻塞启动）。使用默认仓库与路径，可按需改为可配置项。
+            {
+                let app_handle = app.handle();
+                std::thread::spawn(move || {
+                    match handler::announcements::sync_announcements(
+                        "cqw-acq".to_string(),
+                        "RTLauncher_new".to_string(),
+                        "contents".to_string(),
+                        Some("main".to_string()),
+                    ) {
+                        Ok(count) => log::info!("synced {} announcements on startup", count),
+                        Err(e) => log::warn!("sync_announcements failed on startup: {}", e),
+                    }
+                    let _ = app_handle; // keep handle capture for future use
+                });
+            }
 
             // 注册窗口关闭事件：关闭窗口时立即停止 openp2p 进程
             // 注意：这里只做一次快速的 killall（避免阻塞窗口关闭流程）


### PR DESCRIPTION
每次打开启动器就会从github仓库拉取公告

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading localized announcements from an online source, with translated built-in announcements used when unavailable.
  * Announcements now synchronize automatically and display updated titles, content, navigation, and item counts.
  * Instance lists refresh automatically after Forge or NeoForge downloads complete.

* **Bug Fixes**
  * Improved announcement loading reliability through local synchronization and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->